### PR TITLE
Allocate package mem

### DIFF
--- a/database.c
+++ b/database.c
@@ -85,22 +85,29 @@ void parse_csv_line(char line[], struct package* retval) {
     // struct package *retval = malloc(sizeof(struct package*) + (sizeof(char) * strlen(line)));
     // struct package *retval = &(struct package) {
     // struct package retval = {
-    *retval = (struct package) {
-        .name = parsed[0],
-        .description = parsed[1],
-        .version = parsed[2],
-        .archiveurl = parsed[3],
-        .maintainer = parsed[4],
-        .depends = split_space(parsed[5]),
-        .conflicts = split_space(parsed[6]),
-        .configurecmd = parsed[7],
-        .configureopts = split_space(parsed[8]),
-        .type = parsed[9],
-        .sepbuild = parsed[10],
-        .uninstallcmd = parsed[11],
-        .license = parsed[12],
-        .scripts = split_space(parsed[13])
-    };
+    *retval = package_constructor(parsed[0],parsed[1],parsed[2],parsed[3],parsed[4],parsed[7],parsed[9],parsed[10],parsed[11],parsed[12]);
+
+        retval->depends        = split_space(parsed[5]);
+        retval->conflicts      = split_space(parsed[6]);
+        retval->configureopts  = split_space(parsed[8]);
+        retval->scripts        = split_space(parsed[13]);
+
+    /* *retval = (struct package) { */
+    /*     .name = parsed[0], */
+    /*     .description = parsed[1], */
+    /*     .version = parsed[2], */
+    /*     .archiveurl = parsed[3], */
+    /*     .maintainer = parsed[4], */
+    /*     .depends = split_space(parsed[5]), */
+    /*     .conflicts = split_space(parsed[6]), */
+    /*     .configurecmd = parsed[7], */
+    /*     .configureopts = split_space(parsed[8]), */
+    /*     .type = parsed[9], */
+    /*     .sepbuild = parsed[10], */
+    /*     .uninstallcmd = parsed[11], */
+    /*     .license = parsed[12], */
+    /*     .scripts = split_space(parsed[13]) */
+    /* }; */
     printf("%s : %s ( %s )\n", retval->depends.retval[0], retval->conflicts.retval[0], retval->license);
     // printf("%s %s\n", retval->name, (*retval).name);
     // return retval;

--- a/database.c
+++ b/database.c
@@ -1,5 +1,37 @@
 #include "database.h"
 
+struct package package_constructor(char* nameParam, char* descriptionParam, char* versionParam, char* archiveurlParam, char* maintainerParam, char* configurecmdParam, char* typeParam, char* sepbuildParam, char* uninstallcmdParam, char* licenseParam){
+
+    // TODO should be strnlen insteaf of srtlen
+    char *name         = malloc(sizeof(char) * sizeof(strlen(nameParam          )) );
+    char *description  = malloc(sizeof(char) * sizeof(strlen(descriptionParam   )) );
+    char *version      = malloc(sizeof(char) * sizeof(strlen(versionParam       )) );
+    char *archiveurl   = malloc(sizeof(char) * sizeof(strlen(archiveurlParam    )) );
+    char *maintainer   = malloc(sizeof(char) * sizeof(strlen(maintainerParam    )) );
+    char *configurecmd = malloc(sizeof(char) * sizeof(strlen(configurecmdParam  )) );
+    char *type         = malloc(sizeof(char) * sizeof(strlen(typeParam          )) );
+    char *sepbuild     = malloc(sizeof(char) * sizeof(strlen(sepbuildParam      )) );
+    char *uninstallcmd = malloc(sizeof(char) * sizeof(strlen(uninstallcmdParam  )) );
+    char *license      = malloc(sizeof(char) * sizeof(strlen(licenseParam       )) );
+
+    /* struct package* retval = malloc(sizeof(struct package)); */
+
+    struct package retval = (struct package) {
+        .name         = name          ,
+        .description  = description   ,
+        .version      = version       ,
+        .archiveurl   = archiveurl    ,
+        .maintainer   = maintainer    ,
+        .configurecmd = configurecmd  ,
+        .type         = type          ,
+        .sepbuild     = sepbuild      ,
+        .uninstallcmd = uninstallcmd  ,
+        .license      = license       
+    };
+
+    return retval;
+}
+
 struct strarr_retval split_space(char to_split[]) {
     char *p = to_split;
     int spacecount = 0;


### PR DESCRIPTION
Introduced a function, that creates a package, which members are malloced and where the values are copied (structs not included).
With that function the value setting part of `parse_csv_line` was rewritten. This leads to package structs, which data is on the heap instead of the stack and therefore available in higher stack frames.

The `strcpy` call in the "constructor" should become a `strncpy` call (for safety reasons), but then one'd have to set a maximum length for the strings.

Please check for mistakes!