### PR TITLE
Memcpy+sort packages

### DIFF
--- a/config.h
+++ b/config.h
@@ -4,6 +4,6 @@
 // Prefix for basically everything (also config files!)
 // Use for distributing binary packages of this program (for example)
 // Or just simple debugging
-#define INSTALLPREFIX "/home/jonas/kawa_test"
+#define INSTALLPREFIX "/home/lukas/"
 
 #endif // CONFIG_H

--- a/config.mk
+++ b/config.mk
@@ -6,7 +6,7 @@ MANPREFIX = $(PREFIX)/share/man
 CC = gcc
 LD = $(CC)
 CPPFLAGS =
-CFLAGS   = -Wextra -Wall -Os -s
+CFLAGS   = -Wextra -Wall -Os -g
 # LDFLAGS  = -s -lcurl -static
-LDFLAGS  = -s -lcurl
+LDFLAGS  = -lcurl
 # I don't wanna install glibc-static

--- a/database.c
+++ b/database.c
@@ -124,7 +124,7 @@ struct pkglist *get_packages_from_repo(char reponame[]) {
 
     struct pkglist *retval = malloc(sizeof(struct pkglist*) + sizeof(char) * fsize);
     retval->pkg_count = pkg_count;
-    memcpy(retval->packages, packages, sizeof(struct package*) + sizeof(char) * fsize);
+	retval->packages = packages;
     
     fclose(indexfile);
     
@@ -161,7 +161,7 @@ struct pkglist get_all_packages() {
     
     struct pkglist *retval = malloc(sizeof(struct pkglist*) + total_size);
     retval->pkg_count = pkg_count;
-    memcpy(retval->packages, packages, total_size);
+	retval->packages = packages;
     
     printf("Read %d packages from all repos\nAll packages before sorting:", retval->pkg_count);
     for (int c = 0; c < retval->pkg_count; c++)

--- a/database.c
+++ b/database.c
@@ -177,9 +177,9 @@ struct pkglist get_installed_packages() {
 }
 
 int compare_strings(const void* a, const void* b) {
-    struct package *pkgA = (struct package*)a;
-    struct package *pkgB = (struct package*)b;
-    printf(" %s ", pkgA->name);
+    struct package *pkgA = *(struct package**)a;
+    struct package *pkgB = *(struct package**)b;
+    /* printf(" %s ", pkgA->name); */
     return strcmp(pkgA->name, pkgB->name); 
 } 
 

--- a/datatypes.h
+++ b/datatypes.h
@@ -29,7 +29,7 @@ struct package {
 
 struct pkglist {
     int pkg_count;
-    struct package *packages[];
+    struct package **packages;
 };
 
 struct ll_node {

--- a/kawa.c
+++ b/kawa.c
@@ -6,9 +6,5 @@
 #include "update.h"
 
 int main(int argc, char *argv[]) {
-    if (getuid()) {
-        printf("Because error handling is somewhere on TODO, just run this as root for now and everything should be fine.\n");
-        return -1;
-    }
     return update();
 }


### PR DESCRIPTION
Fixed segfault because of memcpy to a random pointer.

Implemented search (by using qsort, depending on how qsort is implemented and is packages inside the repository are already sorted, it might be worth to write an own merge-sort like function)